### PR TITLE
Change pytest.fixture notion: clear page after tests

### DIFF
--- a/smoke_tests/conftest.py
+++ b/smoke_tests/conftest.py
@@ -19,7 +19,7 @@ class NotionTestContext:
     store: AttrDict
 
 
-@pytest.fixture
+@pytest.fixture(scope="session", autouse=True)
 def notion(_cache=[]):
     if _cache:
         return _cache[0]
@@ -34,11 +34,12 @@ def notion(_cache=[]):
     if page is None:
         raise ValueError(f"No such page under url: {page_url}")
 
-    clean_root_page(page)
-
     notion = NotionTestContext(client, page, store)
     _cache.append(notion)
-    return notion
+
+    yield notion
+
+    clean_root_page(page)
 
 
 def clean_root_page(page):


### PR DESCRIPTION
When running the tests, I noticed that after the tests are completed, the elements from the last test remain on the page in notion.

I made minor changes to pytest.fixture notion that remove all elements from the test page _after_ running the tests.

What do you think about the this changes?