### PR TITLE
Request for comments - image urls

### DIFF
--- a/notion/renderer.py
+++ b/notion/renderer.py
@@ -105,7 +105,7 @@ class BaseHTMLRenderer:
         render_sub_pages: bool = True,
         render_with_styles: bool = False,
         render_linked_pages: bool = False,
-        render_table_pages_after_table: bool = False,
+        render_table_pages_after_table: bool = False
     ):
         """
         Attributes
@@ -338,6 +338,10 @@ class BaseHTMLRenderer:
     def render_image(self, block):
         attrs = {"alt": block.caption} if block.caption else {}
         src = block.display_source or block.source
+        path, query = (src.split("?") + [""])[:2]
+        if query == "":
+            query = "table=block&id=" + block.id
+            src = path + "?" + query
         return [img(src=src, **attrs)]
 
     def render_bookmark(self, **_):

--- a/notion/renderer.py
+++ b/notion/renderer.py
@@ -105,7 +105,7 @@ class BaseHTMLRenderer:
         render_sub_pages: bool = True,
         render_with_styles: bool = False,
         render_linked_pages: bool = False,
-        render_table_pages_after_table: bool = False
+        render_table_pages_after_table: bool = False,
     ):
         """
         Attributes

--- a/notion/utils.py
+++ b/notion/utils.py
@@ -196,9 +196,7 @@ def add_signed_prefix_as_needed(url: str, client=None) -> str:
         url = f"{SIGNED_URL_PREFIX}{quote_plus(path)}?{query}"
 
         if client:
-            new_url = client.session.head(url).headers.get("Location")
-            if new_url != None:
-                url = new_url
+            url = client.session.head(url).headers.get("Location", url)
 
     return url
 

--- a/notion/utils.py
+++ b/notion/utils.py
@@ -192,11 +192,13 @@ def add_signed_prefix_as_needed(url: str, client=None) -> str:
         return ""
 
     if url.startswith(S3_URL_PREFIX):
-        path, query = url.split("?")
+        path, query = (url.split("?") + [""])[:2]
         url = f"{SIGNED_URL_PREFIX}{quote_plus(path)}?{query}"
 
         if client:
-            url = client.session.head(url).headers.get("Location")
+            new_url = client.session.head(url).headers.get("Location")
+            if new_url != None:
+                url = new_url
 
     return url
 
@@ -218,7 +220,7 @@ def remove_signed_prefix_as_needed(url: str) -> str:
         Non-prefixed URL.
     """
     if url.startswith(SIGNED_URL_PREFIX):
-        url = unquote_plus(url[len(S3_URL_PREFIX) :])
+        url = unquote_plus(url[len(S3_URL_PREFIX):])
 
     return url or ""
 

--- a/notion/utils.py
+++ b/notion/utils.py
@@ -220,7 +220,7 @@ def remove_signed_prefix_as_needed(url: str) -> str:
         Non-prefixed URL.
     """
     if url.startswith(SIGNED_URL_PREFIX):
-        url = unquote_plus(url[len(S3_URL_PREFIX):])
+        url = unquote_plus(url[len(S3_URL_PREFIX) :])
 
     return url or ""
 


### PR DESCRIPTION
Hi, this is more of an investigation and a question than PR,

I am having problem showing images when rendered to HTML, because URL generated by `notion-py are wrong and not supported by Notion.so.

It is caused by url in the image block missing `?...` query string path.
Original error:
```
File "/Users/ruslan/src/notion-py/notion/utils.py", line 195, in add_signed_prefix_as_needed
ValueError: too many values to unpack (expected 2)
```

I have created a page, shared with public and given view access to specific person.
Do you know why it might be this way?